### PR TITLE
Update SBT.sol: Fixed mutability of 'transfer'

### DIFF
--- a/SBT/SBT.sol
+++ b/SBT/SBT.sol
@@ -19,9 +19,9 @@ contract MySBT {
         return owner;
     }
 
-    function transfer(address to, uint256 tokenId) public {
+    function transfer(address to, uint256 tokenId) public view {
         require(to != address(0), "Invalid address");
-        require(_owners[tokenId] == msg.sender, "You don't own this token");
+        require(_owners[tokenId] == msg.sender, "You dont own this token");
 
         revert("Transfer not applicable");
     }


### PR DESCRIPTION
The mutability of transfer function wasn't restricted to view

changed `don't` to `dont` just to improve code readability (To understand this one, just try viewing the code before merging this pr..you will get it)

Thanks!